### PR TITLE
Fixes#1, findCallers() Not Finding Function Callers in Simulink Functions

### DIFF
--- a/SimulinkFunctions/ChangeScope/findCallers.m
+++ b/SimulinkFunctions/ChangeScope/findCallers.m
@@ -76,8 +76,7 @@ function callers = findCallers(fcn)
                     callers{end+1,1} = calls{j};
                 end
             % caller is in a descendant subsystem (except if atomic), no qualifier needed
-            elseif startsWith(get_param(calls{j}, 'Parent'), parent) ...
-                    && strcmp(get_param(get_param(calls{j}, 'Parent'), 'TreatAsAtomicUnit'), 'off')
+            elseif startsWith(get_param(calls{j}, 'Parent'), parent)
                 if strcmp(proto_basic, get_param(calls{j}, 'FunctionPrototype'))
                     callers{end+1,1} = calls{j};
                 end


### PR DESCRIPTION
### Summary
* Closes #1
* The function was not searching through descendant subsystems if they were atomic subsystems
* I believe the descendant subsystems should be searched regardless of whether they are atomic or not
* Removed the condition which was checking if the descendants were atomic units

### Testing Performed
* Tested on the [FCC](https://groke.cas.mcmaster.ca/gitlab/scotts24/do178) inner loop Filter Simulink Function
* Originally, when running findCallers() on the pink Filter Simulink Function, no callers were found
* Now, findCallers() returns the three Function Callers located in the three Feedback Simulink Functions