### PR TITLE
Functionality to Find Callers of Exported Functions

### DIFF
--- a/SimulinkFunctions/ChangeScope/findCallers.m
+++ b/SimulinkFunctions/ChangeScope/findCallers.m
@@ -1,4 +1,4 @@
-function callers = findCallers(fcn)
+function callers = findCallers(fcn, parentSys)
 % FINDCALLERS Find the Function Caller blocks that call the Simulink function.
 %
 %   Inputs:
@@ -6,6 +6,10 @@ function callers = findCallers(fcn)
 %
 %   Outputs:
 %       callers    Cell array of Function Caller block path names.
+
+    if ~exist('parentSys', 'var')
+        parentSys = [];
+    end
 
     callers = {};
     
@@ -39,10 +43,14 @@ function callers = findCallers(fcn)
     if globalOrScoped
         % Get callers in the whole system
         calls = find_system(blockSys, 'BlockType', 'FunctionCaller');
-        
+        if ~isempty(parentSys)
+            calls = [calls; find_system(parentSys, 'BlockType', 'FunctionCaller')];
+        end
         % Check that the prototype matches
         for i = 1:length(calls)
-            if strcmp(proto_basic, get_param(calls(i), 'FunctionPrototype'))
+            prototype = get_param(calls(i), 'FunctionPrototype');
+            if strcmp(proto_basic, prototype) ...
+            || strcmp(proto_basic, erase(prototype, [blockSys '.'])) 
                 callers{end+1,1} = calls{i};
             end
         end


### PR DESCRIPTION
### Summary of Changes
* Added an optional parameter to `findCallers()`
* Optional parameter specifies a parent model where a caller could possibly reside for the exported Simulink Function
* This is implemented in the [Obfuscate Model](https://github.com/McSCert/Obfuscate-Model) tool

### Example
* Simulink Function `simFcn_A` is defined in root of `Model_A.slx`
* `Model_A.slx` is referenced in `Model_B.slx` and a caller is made to `simFcn_A` namely `simFcn_A_caller`
    * If findCallers is called as `findCallers('Model_A/simFcn_A')`, `simFcn_A_caller` will not be found
    * If findCallers is called as `findCallers('Model_A/simFcn_A', 'Model_B'), the function will also search in Model_B where the model reference to `Model_A` resides, and therefore `simFcn_A_caller` will be found