### PR TITLE
find_system won't return all systems if the pwd isn't the same as the…

### DIFF
--- a/DataflowTracing/subport2inoutblock.m
+++ b/DataflowTracing/subport2inoutblock.m
@@ -43,6 +43,6 @@ function inoutBlock = subport2inoutblock(subPort)
             close_system(parentModel, 0);
         end
     else
-        inoutBlock = cell2mat(find_system(parent, 'SearchDepth', 1, 'BlockType', blockType, 'Port', num2str(pNum)));
+        inoutBlock = cell2mat(find_system(parent, 'LookUnderMasks', 'on', 'FollowLinks', 'on', 'SearchDepth', 1, 'BlockType', blockType, 'Port', num2str(pNum)));
     end
 end


### PR DESCRIPTION
… simulink model. Added additional parameters to find_system() to account for it.